### PR TITLE
changed 0666 to 0660 to fix make error

### DIFF
--- a/src/tuxedo-wmi.c
+++ b/src/tuxedo-wmi.c
@@ -774,7 +774,7 @@ static ssize_t kb_bl_state_store(struct device *dev,
 }
 
 static struct device_attribute kb_bl_state =
-	__ATTR(kb_bl_state, 0666, kb_bl_state_show, kb_bl_state_store);
+	__ATTR(kb_bl_state, 0660, kb_bl_state_show, kb_bl_state_store);
 
 static struct attribute *kb_bl_attrs[] = {
 	&kb_bl_state.attr,


### PR DESCRIPTION
When trying to perform make, I get an error "negative width in bit-field". Tracing back it comes to line 777 (__ATTR(kb_bl_state, 0666, kb_bl_state_show, kb_bl_state_store);). I found a similar issue on another project and their fix was to use 0660, so I changed the line from 0666 to 0660 to test. The make now works correctly
